### PR TITLE
Update file for dh-python, needed to build debian packages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y \
       sudo \
       debhelper \
+      dh-python \
       python3-all \
       python3-numpy \
       python3-setuptools \


### PR DESCRIPTION
Trying to "make deb" will fail w/o dh-python